### PR TITLE
Set up React Hook Form and Validate the Input Fields

### DIFF
--- a/client/.prettierrc
+++ b/client/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "printWidth": 120,
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "all"
+}

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -1,28 +1,28 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
+import js from "@eslint/js";
+import globals from "globals";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  { ignores: ['dist'] },
+  { ignores: ["dist"] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
-    files: ['**/*.{ts,tsx}'],
+    files: ["**/*.{ts,tsx}"],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
     },
     plugins: {
-      'react-hooks': reactHooks,
-      'react-refresh': reactRefresh,
+      "react-hooks": reactHooks,
+      "react-refresh": reactRefresh,
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
-      'react-refresh/only-export-components': [
-        'warn',
+      "react-refresh/only-export-components": [
+        "warn",
         { allowConstantExport: true },
       ],
     },
-  },
-)
+  }
+);

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@fontsource/roboto": "^5.2.5",
+        "@hookform/resolvers": "^5.0.1",
         "@mui/icons-material": "^7.1.0",
         "@mui/material": "^7.1.0",
         "@tanstack/react-query": "^5.75.7",
@@ -22,8 +23,10 @@
         "react": "^18.2.0",
         "react-calendar": "^5.1.0",
         "react-dom": "^18.2.0",
+        "react-hook-form": "^7.56.4",
         "react-router": "^7.6.0",
-        "react-toastify": "^11.0.5"
+        "react-toastify": "^11.0.5",
+        "zod": "^3.24.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -849,6 +852,17 @@
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.0.1.tgz",
+      "integrity": "sha512-u/+Jp83luQNx9AdyW2fIPGY6Y7NG68eN2ZW8FOJYL+M0i4s49+refdJdOp/A9n9HFQtQs3HIDHQvX3ZET2o7YA==",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1502,6 +1516,11 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="
     },
     "node_modules/@swc/core": {
       "version": "1.11.24",
@@ -4020,6 +4039,21 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.56.4",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.56.4.tgz",
+      "integrity": "sha512-Rob7Ftz2vyZ/ZGsQZPaRdIefkgOSrQSPXfqBdvOPwJfoGnjwRJUs7EM7Kc1mcoDv3NOtqBzPGbcMB8CGn9CKgw==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
@@ -4805,7 +4839,6 @@
       "version": "3.24.4",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
       "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@fontsource/roboto": "^5.2.5",
+    "@hookform/resolvers": "^5.0.1",
     "@mui/icons-material": "^7.1.0",
     "@mui/material": "^7.1.0",
     "@tanstack/react-query": "^5.75.7",
@@ -24,8 +25,10 @@
     "react": "^18.2.0",
     "react-calendar": "^5.1.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.56.4",
     "react-router": "^7.6.0",
-    "react-toastify": "^11.0.5"
+    "react-toastify": "^11.0.5",
+    "zod": "^3.24.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/client/src/app/shared/components/TextInput.tsx
+++ b/client/src/app/shared/components/TextInput.tsx
@@ -1,0 +1,23 @@
+import {
+  useController,
+  FieldValues,
+  UseControllerProps,
+} from "react-hook-form";
+import { TextField, TextFieldProps } from "@mui/material";
+
+type Props<T extends FieldValues> = {} & UseControllerProps<T> & TextFieldProps;
+
+export default function TextInput<T extends FieldValues>(props: Props<T>) {
+  const { field, fieldState } = useController({ ...props });
+
+  return (
+    <TextField
+      {...props}
+      {...field}
+      fullWidth
+      variant="outlined"
+      error={!!fieldState.error}
+      helperText={fieldState.error?.message}
+    />
+  );
+}

--- a/client/src/features/activities/details/ActivityDetailsHeader.tsx
+++ b/client/src/features/activities/details/ActivityDetailsHeader.tsx
@@ -85,7 +85,7 @@ export default function ActivityDetailsHeader({ activity }: Props) {
                 variant="contained"
                 color="primary"
                 component={Link}
-                to={`/manage/activityId`}
+                to={`/manage/${activity.id}`}
                 disabled={isCancelled}
               >
                 Manage Event

--- a/client/src/features/activities/form/ActivityForm.tsx
+++ b/client/src/features/activities/form/ActivityForm.tsx
@@ -1,38 +1,31 @@
-import { Box, Button, Paper, TextField, Typography } from "@mui/material";
-import type { FormEvent } from "react";
+import { Box, Button, Paper, Typography } from "@mui/material";
+import { useForm } from "react-hook-form";
+import { useParams } from "react-router";
+import { useEffect } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
 
 import { useActivities } from "../../../lib/hooks/useActivities";
-import { useNavigate, useParams } from "react-router";
+import {
+  activitySchema,
+  type ActivitySchema,
+} from "../../../lib/schemas/activitySchema";
+import TextInput from "../../../app/shared/components/TextInput";
 
 export default function ActivityForm() {
+  const { reset, handleSubmit, control } = useForm<ActivitySchema>({
+    mode: "onTouched",
+    resolver: zodResolver(activitySchema),
+  });
   const { id } = useParams();
   const { updateActivity, createActivity, activity, isLoading } =
     useActivities(id);
-  const navigate = useNavigate();
 
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
+  useEffect(() => {
+    if (activity) reset(activity);
+  }, [activity, reset]);
 
-    const formData = new FormData(event.currentTarget);
-
-    const data: { [key: string]: FormDataEntryValue } = {};
-    formData.forEach((value, key) => {
-      data[key] = value;
-    });
-
-    if (activity) {
-      data.id = activity.id;
-      await updateActivity.mutateAsync(data as unknown as Activity);
-      navigate(`/activities/${activity.id}`);
-    } else {
-      createActivity.mutate(data as unknown as Activity, {
-        onSuccess: (id) => {
-          navigate(`/activities/${id}`);
-        },
-      });
-    }
-
-    // submitForm(data as unknown as Activity);
+  const onSubmit = (data: ActivitySchema) => {
+    console.log(data);
   };
 
   if (isLoading) return <Typography>Loading activity...</Typography>;
@@ -43,37 +36,25 @@ export default function ActivityForm() {
         {activity ? "Edit activity" : "Create activity"}
       </Typography>
       <Box
-        onSubmit={handleSubmit}
+        onSubmit={handleSubmit(onSubmit)}
         component="form"
         display="flex"
         flexDirection="column"
         gap={3}
       >
-        <TextField name="title" defaultValue={activity?.title} label="Title" />
-        <TextField
-          name="description"
-          defaultValue={activity?.description}
+        <TextInput label="Title" control={control} name="title" />
+        <TextInput
           label="Description"
-          multiline={true}
+          control={control}
+          name="description"
+          multiline
           rows={3}
         />
-        <TextField
-          name="category"
-          defaultValue={activity?.category}
-          label="Category"
-        />
-        <TextField
-          name="date"
-          defaultValue={
-            activity?.date
-              ? new Date(activity.date).toISOString().split("T")[0]
-              : new Date().toISOString().split("T")[0]
-          }
-          label="Date"
-          type="date"
-        />
-        <TextField name="city" defaultValue={activity?.city} label="City" />
-        <TextField name="venue" defaultValue={activity?.venue} label="Venue" />
+        <TextInput label="Category" control={control} name="category" />
+        <TextInput label="Date" control={control} name="date" />
+        <TextInput label="City" control={control} name="city" />
+        <TextInput label="Venue" control={control} name="venue" />
+
         <Box display="flex" justifyContent="end" gap={3}>
           <Button color="inherit">Cancel</Button>
           <Button

--- a/client/src/lib/schemas/activitySchema.ts
+++ b/client/src/lib/schemas/activitySchema.ts
@@ -1,17 +1,17 @@
-import { z } from "zod";
+import { z } from 'zod';
 
+//prettier-ignore
 const requiredString = (fieldName: string) =>
-  z
-    .string({ required_error: `${fieldName} is required` })
-    .min(1, { message: `${fieldName} is required` });
+  z.string({ required_error: `${fieldName} is required` })
+   .min(1, { message: `${fieldName} is required` });
 
 export const activitySchema = z.object({
-  title: requiredString("title"),
-  description: requiredString("description"),
-  category: requiredString("category"),
-  date: requiredString("date"),
-  city: requiredString("city"),
-  venue: requiredString("venue"),
+  title: requiredString('title'),
+  description: requiredString('description'),
+  category: requiredString('category'),
+  date: requiredString('date'),
+  city: requiredString('city'),
+  venue: requiredString('venue'),
 });
 
 export type ActivitySchema = z.infer<typeof activitySchema>;

--- a/client/src/lib/schemas/activitySchema.ts
+++ b/client/src/lib/schemas/activitySchema.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+const requiredString = (fieldName: string) =>
+  z
+    .string({ required_error: `${fieldName} is required` })
+    .min(1, { message: `${fieldName} is required` });
+
+export const activitySchema = z.object({
+  title: requiredString("title"),
+  description: requiredString("description"),
+  category: requiredString("category"),
+  date: requiredString("date"),
+  city: requiredString("city"),
+  venue: requiredString("venue"),
+});
+
+export type ActivitySchema = z.infer<typeof activitySchema>;


### PR DESCRIPTION
This PR adds client-side validation to the create activities form, including checks for required fields, title, category, description, date, city, venue
Validation helps prevent invalid user input.
Notes:
I used react-hook-form with MUI TextField components to implement validation.

